### PR TITLE
Add Voltaic Shock localization (button name and tooltip)

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -4634,6 +4634,16 @@
             <Button DefaultButtonFace="AP_ArtanisNoAspect" Requirements="AP_HaveArtanisAnyAspectEquipped"/>
         </InfoArray>
     </CAbilSpecialize>
+    <CAbilEffectInstant id="AP_ArtanisAntiAirWeaponEnable">
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="AP_ArtanisAntiAirWeaponEnable"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_ArtanisAntiAirWeaponEnable" Requirements="AP_HaveArtanisAntiAirWeaponDisabled"/>
+    </CAbilEffectInstant>
+    <CAbilEffectInstant id="AP_ArtanisAntiAirWeaponDisable">
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Effect index="0" value="AP_ArtanisAntiAirWeaponDisable"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_ArtanisAntiAirWeaponDisable" Requirements="AP_HaveArtanisAntiAirWeaponEnabled"/>
+    </CAbilEffectInstant>
     <CAbilEffectTarget id="AP_Exterminate">
         <AbilSetId value="AP_Exterminate"/>
         <Effect index="0" value="AP_ExterminateSet"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -2420,6 +2420,22 @@
         <Hotkey value="Button/Hotkey/AP_Feedback"/>
         <EditorCategories value="Race:Protoss"/>
     </CButton>
+    <CButton id="AP_ArtanisAirAttackControls">
+        <Icon value="Assets\Textures\btn-unit-protoss-dragoon.dds"/>
+        <AlertIcon value="Assets\Textures\btn-unit-protoss-dragoon.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisTemperedInTwilight">
+        <Icon value="Assets\Textures\btn-upgrade-artanis-healingpsionicstorm.dds"/>
+        <AlertIcon value="Assets\Textures\btn-upgrade-artanis-healingpsionicstorm.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisAntiAirWeaponEnable">
+        <Icon value="Assets\Textures\btn-upgrade-protoss-airweaponslevel0.dds"/>
+        <AlertIcon value="Assets\Textures\btn-upgrade-protoss-airweaponslevel0.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisAntiAirWeaponDisable">
+        <Icon value="Assets\Textures\btn-upgrade-protoss-airweaponslevel0.dds"/>
+        <AlertIcon value="Assets\Textures\btn-upgrade-protoss-airweaponslevel0.dds"/>
+    </CButton>
     <CButton id="AP_ArtanisWeaponAspectSwap">
         <Icon value="Assets\Textures\btn-commander-artanis.dds"/>
         <AlertIcon value="Assets\Textures\btn-commander-artanis.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -4597,6 +4597,7 @@
         <EditorCategories value=""/>
         <EffectArray value="AP_ArtanisBlades"/>
         <EffectArray value="AP_ArtanisAstralWindCDRefund"/>
+        <EffectArray value="AP_TemperedInTwilightRefund"/>
     </CEffectSet>
     <CEffectDamage id="AP_ArtanisBlades" parent="DU_WEAP">
         <EditorCategories value="Race:Protoss"/>
@@ -4826,10 +4827,17 @@
     </CEffectModifyUnit>
     <CEffectModifyUnit id="AP_TemperedInTwilightRefund">
         <ImpactUnit Value="Caster"/>
+        <ValidatorArray value="AP_HaveArtanisTemperedInTwilightUpgrade"/>
         <VitalArray index="Energy">
-            <Change value="5"/>
+            <Change value="2"/>
         </VitalArray>
     </CEffectModifyUnit>
+    <CEffectModifyPlayer id="AP_ArtanisAntiAirWeaponEnable">
+        <Upgrades Upgrade="AP_ArtanisAntiAirWeaponDisabledToggle" Count="-1"/>
+    </CEffectModifyPlayer>
+    <CEffectModifyPlayer id="AP_ArtanisAntiAirWeaponDisable">
+        <Upgrades Upgrade="AP_ArtanisAntiAirWeaponDisabledToggle" Count="1"/>
+    </CEffectModifyPlayer>
     <CEffectSet id="AP_VoltaicShockSet">
         <EditorCategories value="Race:Protoss"/>
         <EffectArray value="AP_VoltaicShockDamage"/>
@@ -5140,6 +5148,7 @@
 
     <CEffectSet id="AP_ArtanisAirAttackSet">
         <EffectArray value="AP_ArtanisAirAttackLM"/>
+        <EffectArray value="AP_TemperedInTwilightRefund"/>
     </CEffectSet>
     <CEffectLaunchMissile id="AP_ArtanisAirAttackLM">
         <ImpactEffect value="AP_ArtanisAirAttackDamage"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
@@ -2791,6 +2791,18 @@
     <CRequirement id="AP_HaveArtanisAnyAspectEquipped">
         <NodeArray index="Show" Link="AP_OrArtanisAnyAspectEquippedCompleteOnly"/>
     </CRequirement>
+    <CRequirement id="AP_HaveArtanisTemperedInTwilight">
+        <NodeArray index="Show" Link="AP_CountUpgradeArtanisTemperedInTwilightCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAntiAirWeaponUnlocked">
+        <NodeArray index="Show" Link="AP_CountUpgradeArtanisAntiAirWeaponUnlockedCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAntiAirWeaponEnabled">
+        <NodeArray index="Show" Link="AP_AndArtanisAntiAirWeaponEnabledCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAntiAirWeaponDisabled">
+        <NodeArray index="Show" Link="AP_AndArtanisAntiAirWeaponDisabledCompleteOnly"/>
+    </CRequirement>
     <CRequirement id="AP_HaveSOADragoonRevive">
         <EditorCategories value="Race:Protoss,TechType:Ability"/>
         <NodeArray index="Show" Link="AP_CountUpgradeSOADragoonReviveCompleteOnly"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
@@ -5196,6 +5196,26 @@
     </CRequirementAnd>
         
 
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisTemperedInTwilightCompleteOnly">
+        <Count Link="AP_ArtanisTemperedInTwilight" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisAntiAirWeaponUnlockedCompleteOnly">
+        <Count Link="AP_ArtanisAntiAirWeaponUnlocked" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisAntiAirWeaponDisabledToggleCompleteOnly">
+        <Count Link="AP_ArtanisAntiAirWeaponDisabledToggle" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
+    <CRequirementNot id="AP_NotCountUpgradeArtanisAntiAirWeaponDisabledToggleCompleteOnly">
+        <OperandArray index="0" value="AP_CountUpgradeArtanisAntiAirWeaponDisabledToggleCompleteOnly"/>
+    </CRequirementNot>
+    <CRequirementAnd id="AP_AndArtanisAntiAirWeaponEnabledCompleteOnly">
+        <OperandArray value="AP_CountUpgradeArtanisAntiAirWeaponUnlockedCompleteOnly"/>
+        <OperandArray value="AP_NotCountUpgradeArtanisAntiAirWeaponDisabledToggleCompleteOnly"/>
+    </CRequirementAnd>
+    <CRequirementAnd id="AP_AndArtanisAntiAirWeaponDisabledCompleteOnly">
+        <OperandArray value="AP_CountUpgradeArtanisAntiAirWeaponUnlockedCompleteOnly"/>
+        <OperandArray value="AP_CountUpgradeArtanisAntiAirWeaponDisabledToggleCompleteOnly"/>
+    </CRequirementAnd>
     <CRequirementCountUpgrade id="AP_CountUpgradeSOAFenixCompleteOnly">
         <Flags index="TechTreeCheat" value="0"/>
         <Tooltip value=""/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -14658,6 +14658,8 @@
         <AbilArray Link="Warpable"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="AP_ArtanisWeaponAspects"/>
+        <AbilArray Link="AP_ArtanisAntiAirWeaponEnable"/>
+        <AbilArray Link="AP_ArtanisAntiAirWeaponDisable"/>
         <AbilArray Link="AP_SuppressionPulse"/>
         <AbilArray Link="AP_ArtanisLightningDash"/>
         <AbilArray Link="AP_ArtanisAstralWind"/>
@@ -14698,6 +14700,13 @@
             <LayoutButtons Face="AP_PhasePrism" Type="AbilCmd" AbilCmd="AP_PhasePrism,Execute" Row="1" Column="1"/>
             <LayoutButtons Face="ArtanisForceOfWill" Type="Passive" Row="2" Column="3"/>
             <LayoutButtons Face="AP_ArtanisWeaponAspectSwap" Type="Submenu" SubmenuCardId="WA" Row="2" Column="1"/>
+            <LayoutButtons Face="AP_ArtanisAirAttackControls" Type="Submenu" SubmenuCardId="AA" Requirements="AP_HaveArtanisAntiAirWeaponUnlocked" Row="1" Column="4"/>
+        </CardLayouts>
+        <CardLayouts CardId="AA">
+            <LayoutButtons Face="AP_ArtanisTemperedInTwilight" Type="Passive" Requirements="AP_HaveArtanisTemperedInTwilight" Row="0" Column="0"/>
+            <LayoutButtons Face="AP_ArtanisAntiAirWeaponEnable" Type="AbilCmd" AbilCmd="AP_ArtanisAntiAirWeaponEnable,Execute" Requirements="AP_HaveArtanisAntiAirWeaponDisabled" Row="1" Column="0"/>
+            <LayoutButtons Face="AP_ArtanisAntiAirWeaponDisable" Type="AbilCmd" AbilCmd="AP_ArtanisAntiAirWeaponDisable,Execute" Requirements="AP_HaveArtanisAntiAirWeaponEnabled" Row="1" Column="2"/>
+            <LayoutButtons Face="Cancel" Type="CancelSubmenu" Row="2" Column="4"/>
         </CardLayouts>
         <CardLayouts CardId="WA">
             <LayoutButtons Face="AP_ArtanisAiurAspect" Type="AbilCmd" AbilCmd="AP_ArtanisWeaponAspects,0" Row="0" Column="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -12835,6 +12835,18 @@
     <CUpgrade id="AP_ArtanisTaldarimAspectActive"/>
     <CUpgrade id="AP_ArtanisTaldarimAspectPassive"/>
 
+    <CUpgrade id="AP_ArtanisTemperedInTwilight"/>
+    <CUpgrade id="AP_ArtanisAntiAirWeaponUnlocked">
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Options[Hidden]" Value="0"/>
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Options[Disabled]" Value="0"/>
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Period" Value="0.8"/>
+        <AffectedUnitArray value="AP_ArtanisHero"/>
+    </CUpgrade>
+    <CUpgrade id="AP_ArtanisAntiAirWeaponDisabledToggle">
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Options[Hidden]" Value="1"/>
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Options[Disabled]" Value="1"/>
+        <AffectedUnitArray value="AP_ArtanisHero"/>
+    </CUpgrade>
     <CUpgrade id="AP_VoidRaySpeedUpgrade">
         <ScoreAmount value="300"/>
         <ScoreResult value="BuildOrder"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -5366,6 +5366,9 @@
         <CombineArray value="AP_HaveDarkArchonMindControl"/>
         <CombineArray value="AP_IsParasiticDominated"/>
     </CValidatorCombine>
+    <CValidatorPlayerRequirement id="AP_HaveArtanisTemperedInTwilightUpgrade">
+        <Value value="AP_HaveArtanisTemperedInTwilight"/>
+    </CValidatorPlayerRequirement>
     <CValidatorPlayerRequirement id="AP_HaveSOARepairBeamAllyUpgrade">
         <WhichPlayer Value="Target"/>
         <ResultNoPlayer value="Error"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2789,11 +2789,13 @@
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_ArtanisAirAttack">
         <EditorCategories value="Race:Protoss"/>
+        <Options index="Hidden" value="1"/>
+        <Options index="Disabled" value="1"/>
         <Icon value="Assets\Textures\btn-upgrade-protoss-groundweaponslevel0.dds"/>
         <DisplayEffect value="AP_ArtanisAirAttackDamage"/>
         <TargetFilters value="Air,Visible;Ground,Missile,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="4"/>
-        <Period value="1"/>
+        <Period value="0.8"/>
         <DamagePoint value="0.2"/>
         <Effect value="AP_ArtanisAirAttackSet"/>
     </CWeaponLegacy>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -1138,6 +1138,10 @@ Button/Name/AP_ArtanisNoAspect=Alone
 Button/Name/AP_ArtanisPurifierAspect=Purifier Aspect
 Button/Name/AP_ArtanisTaldarimAspect=Tal'darim Aspect
 Button/Name/AP_ArtanisWeaponAspectSwap=Swap Weapon Aspects
+Button/Name/AP_ArtanisAirAttackControls=Anti-Air Controls
+Button/Name/AP_ArtanisTemperedInTwilight=Tempered in Twilight
+Button/Name/AP_ArtanisAntiAirWeaponEnable=Enable Anti-Air Weapon
+Button/Name/AP_ArtanisAntiAirWeaponDisable=Disable Anti-Air Weapon
 Button/Name/AP_AscendantAbilityEfficiency=Breath of Creation
 Button/Name/AP_AscendantSacrifice=Sacrifice
 Button/Name/AP_AssaultModeMengsk=Assault Mode
@@ -2589,6 +2593,10 @@ Button/Tooltip/AP_ArtanisNoAspect=Artanis removes his current Weapon Aspect, ret
 Button/Tooltip/AP_ArtanisPurifierAspect=Switch Artanis' active aspect to <c val="f2bf16">Purifier</c>, granting him access to any unlocked bonuses and making him count as a <c val="f2bf16">Purifier</c> unit.
 Button/Tooltip/AP_ArtanisTaldarimAspect=Switch Artanis' active aspect to <c val="d40d24">Taldarim</c>, granting him access to any unlocked bonuses and making him count as a <c val="d40d24">Taldarim</c> unit.
 Button/Tooltip/AP_ArtanisWeaponAspectSwap=Swap Artanis to a different weapon aspect.
+Button/Tooltip/AP_ArtanisAirAttackControls=Open anti-air controls for Artanis.
+Button/Tooltip/AP_ArtanisTemperedInTwilight=Passive: Artanis restores 2 energy whenever he deals attack damage with his melee or anti-air weapon.
+Button/Tooltip/AP_ArtanisAntiAirWeaponEnable=Enable Artanis' anti-air weapon.
+Button/Tooltip/AP_ArtanisAntiAirWeaponDisable=Disable Artanis' anti-air weapon.
 Button/Tooltip/AP_AscendantAbilityEfficiency=Ascendant abilities cost <d ref="Upgrade,AP_AscendantAbilityEfficiency,EffectArray[0].Value"/> less energy.<n/><n/><c val="FFE303">War Council Upgrade.</c>
 Button/Tooltip/AP_AscendantSacrifice=Reduces target friendly unit to <d ref="Effect,AP_AscendantSacrificeDamage,Amount"/> life (shields are not affected).<n/><n/>Grants the Ascendant <d ref="Effect,AP_AscendantSacrificeDamage5,LeechFraction[Energy]"/> energy for each life point reduced, up to its maximum energy.<n/><n/><c val="#ColorAttackInfo">Can only target friendly units.</c>
 Button/Tooltip/AP_AssaultModeMengsk=Transforms the Sky Fury to Assault Mode. In this mode Sky Furies move on the ground and can only attack ground targets.
@@ -7396,3 +7404,6 @@ Weapon/Tip/AP_Talons=
 Weapon/Tip/AP_VoidRayChargeBeamBounce=Deals <d ref="Effect,AP_VoidRayChargeBeamBounce1Damage,Amount"/> damage to <d ref="Effect,AP_VoidRayChargeBeamBounce1Search,MaxCount"/> secondary target if not charged,<n/><d ref="Effect,AP_VoidRayChargeBeamBounce2Damage,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBounce2Damage,Amount + Effect,AP_VoidRayChargeBeamBounce2Damage,AttributeBonus[Armored]"/> vs Armored) damage to <d ref="Effect,AP_VoidRayChargeBeamBounce2Search,MaxCount"/> secondary targets if halfway charged,<n/><d ref="Effect,AP_VoidRayChargeBeamBounce3Damage,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBounce3Damage,Amount + Effect,AP_VoidRayChargeBeamBounce3Damage,AttributeBonus[Armored]"/> vs Armored) damage to <d ref="Effect,AP_VoidRayChargeBeamBounce3Search,MaxCount"/> secondary targets damage if fully charged.
 Weapon/Tip/AP_VoidRayChargeBeamBounceUpgraded=Deals <d ref="Effect,AP_VoidRayChargeBeamBounceDamageUpgraded,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBounceDamageUpgraded,Amount + Effect,AP_VoidRayChargeBeamBounceDamageUpgraded,AttributeBonus[Armored]"/> vs Armored) damage to to secondary targets at all charge levels. Hits 1 additional target per charge level.
 Weapon/Tip/AP_VoidRayChargeBeamRange=Deals <d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge2,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge2,Amount + Effect,AP_VoidRayChargeBeamBaseDamageCharge2,AttributeBonus[Armored]"/> vs Armored) damage if halfway charged,<n/><d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge3,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge3,Amount + Effect,AP_VoidRayChargeBeamBaseDamageCharge3,AttributeBonus[Armored]"/> vs Armored) damage if fully charged.
+
+Abil/Name/AP_ArtanisAntiAirWeaponEnable=Enable Anti-Air Weapon
+Abil/Name/AP_ArtanisAntiAirWeaponDisable=Disable Anti-Air Weapon

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2375,6 +2375,7 @@ Button/Name/AP_VoidVoidRayBeamBounce=Destruction Beam
 Button/Name/AP_VoidZealotShadowCharge=Shadow Charge
 Button/Name/AP_VoidZealotShadowChargeStun=Darkcoil
 Button/Name/AP_VoidZealotWhirlwind=Whirlwind
+Button/Name/AP_VoltaicShock=Voltaic Shock
 Button/Name/AP_Vulture=Build Vulture
 Button/Name/AP_VultureAutoLaunchers=Auto Launchers
 Button/Name/AP_VultureAutoRepair=Jerry-Rigged Patchup
@@ -4078,6 +4079,7 @@ Button/Tooltip/AP_VoidVoidRayBeamBounce=Prismatic Beam splits and deals damage t
 Button/Tooltip/AP_VoidZealotShadowCharge=Intercepts enemy ground units. Briefly cloaks the Centurion and allows it to move through other units.
 Button/Tooltip/AP_VoidZealotShadowChargeStun=Stuns target enemy ground unit and all nearby enemy ground units <d ref="Behavior,AP_VoidZealotShadowChargeStun,Duration" precision="1"/> seconds.</n></n><c val="#ColorAttackInfo">Massive units are slowed.</c>
 Button/Tooltip/AP_VoidZealotWhirlwind=Deals <d ref="Effect,AP_VoidZealotWhirlwindDamage,Amount/Behavior,AP_VoidZealotWhirlwind,Period"/> damage per second to all nearby enemy units. Lasts <d ref="Behavior,AP_VoidZealotWhirlwind,Duration"/> seconds.
+Button/Tooltip/AP_VoltaicShock=Unleash an electrical blast at the target point, dealing <d ref="Effect,AP_VoltaicShockDamage,Amount"/> damage to air units and <d ref="Effect,AP_VoltaicShockDamageSecondary,Amount"/> damage to enemies in the area.<n/><n/>Affected air units are grounded and unable to move for <d ref="Behavior,AP_VoltaicShock,Duration"/> seconds.
 Button/Tooltip/AP_Vulture=Fast skirmish unit. Can use the Spider Mine ability.<n/><n/><c val="#ColorAttackInfo">Can attack ground units.</c>
 Button/Tooltip/AP_VultureAutoLaunchers=Vulture can attack while moving
 Button/Tooltip/AP_VultureAutoRepair=Vulture regenerates life.


### PR DESCRIPTION
### Motivation
- Provide a localized button label and tooltip for the ability `AP_VoltaicShock` so the UI displays descriptive text in the English strings file.

### Description
- Added `Button/Name/AP_VoltaicShock=Voltaic Shock` and `Button/Tooltip/AP_VoltaicShock=Unleash an electrical blast at the target point, dealing <d ref="Effect,AP_VoltaicShockDamage,Amount"/> damage to air units and <d ref="Effect,AP_VoltaicShockDamageSecondary,Amount"/> damage to enemies in the area.<n/><n/>Affected air units are grounded and unable to move for <d ref="Behavior,AP_VoltaicShock,Duration"/> seconds.` to `Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt`.

### Testing
- Ran `rg -n "AP_VoltaicShock" Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt` to verify the new entries were present, which succeeded.
- Inspected the file context with `nl -ba Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt | sed -n '2372,2382p;4076,4086p'` to confirm proper placement, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f74779ef48332a8dfb5ffe64fef46)