### PR TITLE
Add Artanis passive "Tempered in Twilight" and unlockable anti-air toggle

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -4634,6 +4634,18 @@
             <Button DefaultButtonFace="AP_ArtanisNoAspect" Requirements="AP_HaveArtanisAnyAspectEquipped"/>
         </InfoArray>
     </CAbilSpecialize>
+    <CAbilBehavior id="AP_ArtanisAirAttackToggle">
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <CmdButtonArray index="On" DefaultButtonFace="AP_ArtanisAntiAirDisable" Requirements="AP_HaveArtanisAntiAirWeaponUnlocked">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+        <CmdButtonArray index="Off" DefaultButtonFace="AP_ArtanisAntiAirEnable" Requirements="AP_HaveArtanisAntiAirWeaponUnlocked">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+        <Flags index="Toggle" value="1"/>
+        <Flags index="Transient" value="1"/>
+        <BehaviorArray value="AP_ArtanisAirAttackDisabled"/>
+    </CAbilBehavior>
     <CAbilEffectTarget id="AP_Exterminate">
         <AbilSetId value="AP_Exterminate"/>
         <Effect index="0" value="AP_ExterminateSet"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -2207,6 +2207,13 @@
         <RemoveValidatorArray value="AP_NoArtanisBladeWaltzRecastWalkSpeed"/>
         <Duration value="2"/>
     </CBehaviorBuff>
+    <CBehaviorBuff id="AP_ArtanisAirAttackDisabled">
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <InfoFlags index="Hidden" value="1"/>
+        <Modification>
+            <WeaponDisableArray value="AP_ArtanisAirAttack"/>
+        </Modification>
+    </CBehaviorBuff>
     <CBehaviorBuff id="AP_StrengthInUnity">
         <EditorCategories value="AbilityorEffectType:Units,Race:Protoss"/>
         <Duration value="15"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -2425,6 +2425,22 @@
         <AlertIcon value="Assets\Textures\btn-commander-artanis.dds"/>
         <Hotkey value="Button/Hotkey/AP_ArtanisWeaponAspects"/>
     </CButton>
+    <CButton id="AP_ArtanisPassiveSystems">
+        <Icon value="Assets\Textures\btn-ability-protoss-adunlegacy.dds"/>
+        <AlertIcon value="Assets\Textures\btn-ability-protoss-adunlegacy.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisTemperedInTwilight">
+        <Icon value="AP\Assets\Textures\btn-upgrade-protoss-artanis-spiritsfire.dds"/>
+        <AlertIcon value="AP\Assets\Textures\btn-upgrade-protoss-artanis-spiritsfire.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisAntiAirEnable">
+        <Icon value="Assets\Textures\btn-unit-protoss-phoenix.dds"/>
+        <AlertIcon value="Assets\Textures\btn-unit-protoss-phoenix.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisAntiAirDisable">
+        <Icon value="Assets\Textures\btn-upgrade-protoss-phoenixionpulsecrystals.dds"/>
+        <AlertIcon value="Assets\Textures\btn-upgrade-protoss-phoenixionpulsecrystals.dds"/>
+    </CButton>
     <CButton id="AP_ArtanisAiurAspect">
         <Icon value="AP\Assets\Textures\ui_void_armyupgrade_factionaiur_categoryicon.dds"/>
         <AlertIcon value="AP\Assets\Textures\ui_void_armyupgrade_factionaiur_categoryicon.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -4596,6 +4596,7 @@
     <CEffectSet id="AP_ArtanisBladesSet">
         <EditorCategories value=""/>
         <EffectArray value="AP_ArtanisBlades"/>
+        <EffectArray value="AP_ArtanisTemperedInTwilightEnergy"/>
         <EffectArray value="AP_ArtanisAstralWindCDRefund"/>
     </CEffectSet>
     <CEffectDamage id="AP_ArtanisBlades" parent="DU_WEAP">
@@ -4607,6 +4608,12 @@
     <CEffectModifyUnit id="AP_ArtanisAstralWindCDRefund">
         <ImpactUnit Value="Caster"/>
         <Cost Abil="AP_ArtanisAstralWind,Execute" CooldownOperation="Add" CooldownTimeUse="-5.0"/>
+    </CEffectModifyUnit>
+    <CEffectModifyUnit id="AP_ArtanisTemperedInTwilightEnergy">
+        <EditorCategories value="Race:Protoss"/>
+        <ImpactUnit Value="Caster"/>
+        <ValidatorArray value="AP_HaveArtanisTemperedInTwilight"/>
+        <VitalArray index="Energy" Change="2"/>
     </CEffectModifyUnit>
     
     <CEffectApplyBehavior id="AP_ArtanisAiurAspect"/>
@@ -5142,10 +5149,14 @@
         <EffectArray value="AP_ArtanisAirAttackLM"/>
     </CEffectSet>
     <CEffectLaunchMissile id="AP_ArtanisAirAttackLM">
-        <ImpactEffect value="AP_ArtanisAirAttackDamage"/>
+        <ImpactEffect value="AP_ArtanisAirAttackImpactSet"/>
         <Movers Link="MissileDefault"/>
         <AmmoUnit value="AP_ArtanisAirAttackWeapon"/>
     </CEffectLaunchMissile>
+    <CEffectSet id="AP_ArtanisAirAttackImpactSet">
+        <EffectArray value="AP_ArtanisAirAttackDamage"/>
+        <EffectArray value="AP_ArtanisTemperedInTwilightEnergy"/>
+    </CEffectSet>
     <CEffectCreatePersistent id="AP_ArtanisAirAttack">
         <EditorCategories value="Race:Protoss"/>
         <WhichLocation Value="TargetUnit"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
@@ -2791,6 +2791,18 @@
     <CRequirement id="AP_HaveArtanisAnyAspectEquipped">
         <NodeArray index="Show" Link="AP_OrArtanisAnyAspectEquippedCompleteOnly"/>
     </CRequirement>
+    <CRequirement id="AP_HaveArtanisTemperedInTwilight">
+        <NodeArray index="Show" Link="AP_CountUpgradeArtanisTemperedInTwilightCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAntiAirWeaponUnlocked">
+        <NodeArray index="Show" Link="AP_CountUpgradeArtanisUnlockedAntiAirProtocolCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAntiAirWeaponEnableButton">
+        <NodeArray index="Show" Link="AP_AndArtanisAntiAirEnableButtonCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAntiAirWeaponDisableButton">
+        <NodeArray index="Show" Link="AP_AndArtanisAntiAirDisableButtonCompleteOnly"/>
+    </CRequirement>
     <CRequirement id="AP_HaveSOADragoonRevive">
         <EditorCategories value="Race:Protoss,TechType:Ability"/>
         <NodeArray index="Show" Link="AP_CountUpgradeSOADragoonReviveCompleteOnly"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
@@ -5130,6 +5130,31 @@
         <OperandArray value="AP_CountBehaviorArtanisTaldarimAspectCompleteOnlyAtUnit"/>
     </CRequirementOr>
 
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisTemperedInTwilightCompleteOnly">
+        <Count Link="AP_ArtanisTemperedInTwilight" State="CompleteOnly"/>
+        <Flags index="TechTreeCheat" value="0"/>
+    </CRequirementCountUpgrade>
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisUnlockedAntiAirProtocolCompleteOnly">
+        <Count Link="AP_ArtanisUnlockedAntiAirProtocol" State="CompleteOnly"/>
+        <Flags index="TechTreeCheat" value="0"/>
+    </CRequirementCountUpgrade>
+    <CRequirementCountBehavior id="AP_CountBehaviorArtanisAirAttackDisabledCompleteOnlyAtUnit">
+        <Count Link="AP_ArtanisAirAttackDisabled" State="CompleteOnlyAtUnit"/>
+        <Flags index="IgnoreDead" value="1"/>
+    </CRequirementCountBehavior>
+    <CRequirementNot id="AP_NotCountBehaviorArtanisAirAttackDisabledCompleteOnlyAtUnit">
+        <OperandArray value="AP_CountBehaviorArtanisAirAttackDisabledCompleteOnlyAtUnit"/>
+        <Flags index="IgnoreDead" value="1"/>
+    </CRequirementNot>
+    <CRequirementAnd id="AP_AndArtanisAntiAirEnableButtonCompleteOnly">
+        <OperandArray value="AP_CountUpgradeArtanisUnlockedAntiAirProtocolCompleteOnly"/>
+        <OperandArray value="AP_CountBehaviorArtanisAirAttackDisabledCompleteOnlyAtUnit"/>
+    </CRequirementAnd>
+    <CRequirementAnd id="AP_AndArtanisAntiAirDisableButtonCompleteOnly">
+        <OperandArray value="AP_CountUpgradeArtanisUnlockedAntiAirProtocolCompleteOnly"/>
+        <OperandArray value="AP_NotCountBehaviorArtanisAirAttackDisabledCompleteOnlyAtUnit"/>
+    </CRequirementAnd>
+
 
     <CRequirementCountUpgrade id="AP_CountUpgradeArtanisPurifierAspectUnlockedCompleteOnly">
         <Count Link="AP_ArtanisPurifierAspectUnlocked" State="CompleteOnly"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -14658,6 +14658,7 @@
         <AbilArray Link="Warpable"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="AP_ArtanisWeaponAspects"/>
+        <AbilArray Link="AP_ArtanisAirAttackToggle"/>
         <AbilArray Link="AP_SuppressionPulse"/>
         <AbilArray Link="AP_ArtanisLightningDash"/>
         <AbilArray Link="AP_ArtanisAstralWind"/>
@@ -14673,6 +14674,7 @@
         <AbilArray Link="ArtanisChannel"/>
         <BehaviorArray Link="AP_ArtanisNoAspect"/>
         <BehaviorArray Link="AP_ArtanisResurgence"/>
+        <BehaviorArray Link="AP_ArtanisAirAttackDisabled"/>
         <WeaponArray Link="AP_ArtanisTwilightBlades"/>
         <WeaponArray Link="AP_ArtanisAirAttack"/>
         <CardLayouts>
@@ -14698,6 +14700,7 @@
             <LayoutButtons Face="AP_PhasePrism" Type="AbilCmd" AbilCmd="AP_PhasePrism,Execute" Row="1" Column="1"/>
             <LayoutButtons Face="ArtanisForceOfWill" Type="Passive" Row="2" Column="3"/>
             <LayoutButtons Face="AP_ArtanisWeaponAspectSwap" Type="Submenu" SubmenuCardId="WA" Row="2" Column="1"/>
+            <LayoutButtons Face="AP_ArtanisPassiveSystems" Type="Submenu" SubmenuCardId="PS" Row="1" Column="4"/>
         </CardLayouts>
         <CardLayouts CardId="WA">
             <LayoutButtons Face="AP_ArtanisAiurAspect" Type="AbilCmd" AbilCmd="AP_ArtanisWeaponAspects,0" Row="0" Column="0"/>
@@ -14705,6 +14708,12 @@
             <LayoutButtons Face="AP_ArtanisPurifierAspect" Type="AbilCmd" AbilCmd="AP_ArtanisWeaponAspects,2" Row="0" Column="2"/>
             <LayoutButtons Face="AP_ArtanisTaldarimAspect" Type="AbilCmd" AbilCmd="AP_ArtanisWeaponAspects,3" Row="0" Column="3"/>
             <LayoutButtons Face="AP_ArtanisNoAspect" Type="AbilCmd" AbilCmd="AP_ArtanisWeaponAspects,4" Row="0" Column="4"/>
+            <LayoutButtons Face="Cancel" Type="CancelSubmenu" Row="2" Column="4"/>
+        </CardLayouts>
+        <CardLayouts CardId="PS">
+            <LayoutButtons Face="AP_ArtanisTemperedInTwilight" Type="Passive" Requirements="AP_HaveArtanisTemperedInTwilight" Row="0" Column="0"/>
+            <LayoutButtons Face="AP_ArtanisAntiAirEnable" Type="AbilCmd" AbilCmd="AP_ArtanisAirAttackToggle,Off" Requirements="AP_HaveArtanisAntiAirWeaponEnableButton" Row="0" Column="1"/>
+            <LayoutButtons Face="AP_ArtanisAntiAirDisable" Type="AbilCmd" AbilCmd="AP_ArtanisAirAttackToggle,On" Requirements="AP_HaveArtanisAntiAirWeaponDisableButton" Row="0" Column="2"/>
             <LayoutButtons Face="Cancel" Type="CancelSubmenu" Row="2" Column="4"/>
         </CardLayouts>
         <Radius value="0.425"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -12834,6 +12834,11 @@
     <CUpgrade id="AP_ArtanisTaldarimAspectUnlocked"/>
     <CUpgrade id="AP_ArtanisTaldarimAspectActive"/>
     <CUpgrade id="AP_ArtanisTaldarimAspectPassive"/>
+    <CUpgrade id="AP_ArtanisTemperedInTwilight"/>
+    <CUpgrade id="AP_ArtanisUnlockedAntiAirProtocol">
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Options[Disabled]" Value="0"/>
+        <EffectArray Operation="Set" Reference="Weapon,AP_ArtanisAirAttack,Options[Hidden]" Value="0"/>
+    </CUpgrade>
 
     <CUpgrade id="AP_VoidRaySpeedUpgrade">
         <ScoreAmount value="300"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -37,6 +37,10 @@
         <Find value="1"/>
         <Value value="AP_HaveHotSLurker"/>
     </CValidatorPlayerRequirement>
+    <CValidatorPlayerRequirement id="AP_HaveArtanisTemperedInTwilight">
+        <Find value="1"/>
+        <Value value="AP_HaveArtanisTemperedInTwilight"/>
+    </CValidatorPlayerRequirement>
     <CValidatorPlayerRequirement id="AP_HaveHotSMutaliskViper">
         <Find value="1"/>
         <Value value="AP_HaveHotSMutaliskViper"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2793,8 +2793,10 @@
         <DisplayEffect value="AP_ArtanisAirAttackDamage"/>
         <TargetFilters value="Air,Visible;Ground,Missile,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="4"/>
-        <Period value="1"/>
+        <Period value="0.8"/>
         <DamagePoint value="0.2"/>
+        <Options index="Disabled" value="1"/>
+        <Options index="Hidden" value="1"/>
         <Effect value="AP_ArtanisAirAttackSet"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_Claws">

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2375,6 +2375,7 @@ Button/Name/AP_VoidVoidRayBeamBounce=Destruction Beam
 Button/Name/AP_VoidZealotShadowCharge=Shadow Charge
 Button/Name/AP_VoidZealotShadowChargeStun=Darkcoil
 Button/Name/AP_VoidZealotWhirlwind=Whirlwind
+Button/Name/AP_VoltaicShock=Voltaic Shock
 Button/Name/AP_Vulture=Build Vulture
 Button/Name/AP_VultureAutoLaunchers=Auto Launchers
 Button/Name/AP_VultureAutoRepair=Jerry-Rigged Patchup
@@ -4078,6 +4079,7 @@ Button/Tooltip/AP_VoidVoidRayBeamBounce=Prismatic Beam splits and deals damage t
 Button/Tooltip/AP_VoidZealotShadowCharge=Intercepts enemy ground units. Briefly cloaks the Centurion and allows it to move through other units.
 Button/Tooltip/AP_VoidZealotShadowChargeStun=Stuns target enemy ground unit and all nearby enemy ground units <d ref="Behavior,AP_VoidZealotShadowChargeStun,Duration" precision="1"/> seconds.</n></n><c val="#ColorAttackInfo">Massive units are slowed.</c>
 Button/Tooltip/AP_VoidZealotWhirlwind=Deals <d ref="Effect,AP_VoidZealotWhirlwindDamage,Amount/Behavior,AP_VoidZealotWhirlwind,Period"/> damage per second to all nearby enemy units. Lasts <d ref="Behavior,AP_VoidZealotWhirlwind,Duration"/> seconds.
+Button/Tooltip/AP_VoltaicShock=Unleash an electrical blast at the target point, dealing <d ref="Effect,AP_VoltaicShockDamage,Amount"/> damage to air units and <d ref="Effect,AP_VoltaicShockDamageSecondary,Amount"/> damage to enemies in the area.<n/><n/>Affected air units are grounded and unable to move for <d ref="Behavior,AP_VoltaicShock,Duration"/> seconds.
 Button/Tooltip/AP_Vulture=Fast skirmish unit. Can use the Spider Mine ability.<n/><n/><c val="#ColorAttackInfo">Can attack ground units.</c>
 Button/Tooltip/AP_VultureAutoLaunchers=Vulture can attack while moving
 Button/Tooltip/AP_VultureAutoRepair=Vulture regenerates life.
@@ -7394,3 +7396,12 @@ Weapon/Tip/AP_Talons=
 Weapon/Tip/AP_VoidRayChargeBeamBounce=Deals <d ref="Effect,AP_VoidRayChargeBeamBounce1Damage,Amount"/> damage to <d ref="Effect,AP_VoidRayChargeBeamBounce1Search,MaxCount"/> secondary target if not charged,<n/><d ref="Effect,AP_VoidRayChargeBeamBounce2Damage,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBounce2Damage,Amount + Effect,AP_VoidRayChargeBeamBounce2Damage,AttributeBonus[Armored]"/> vs Armored) damage to <d ref="Effect,AP_VoidRayChargeBeamBounce2Search,MaxCount"/> secondary targets if halfway charged,<n/><d ref="Effect,AP_VoidRayChargeBeamBounce3Damage,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBounce3Damage,Amount + Effect,AP_VoidRayChargeBeamBounce3Damage,AttributeBonus[Armored]"/> vs Armored) damage to <d ref="Effect,AP_VoidRayChargeBeamBounce3Search,MaxCount"/> secondary targets damage if fully charged.
 Weapon/Tip/AP_VoidRayChargeBeamBounceUpgraded=Deals <d ref="Effect,AP_VoidRayChargeBeamBounceDamageUpgraded,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBounceDamageUpgraded,Amount + Effect,AP_VoidRayChargeBeamBounceDamageUpgraded,AttributeBonus[Armored]"/> vs Armored) damage to to secondary targets at all charge levels. Hits 1 additional target per charge level.
 Weapon/Tip/AP_VoidRayChargeBeamRange=Deals <d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge2,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge2,Amount + Effect,AP_VoidRayChargeBeamBaseDamageCharge2,AttributeBonus[Armored]"/> vs Armored) damage if halfway charged,<n/><d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge3,Amount"/> (<d ref="Effect,AP_VoidRayChargeBeamBaseDamageCharge3,Amount + Effect,AP_VoidRayChargeBeamBaseDamageCharge3,AttributeBonus[Armored]"/> vs Armored) damage if fully charged.
+
+Button/Name/AP_ArtanisPassiveSystems=Passive Systems
+Button/Name/AP_ArtanisTemperedInTwilight=Tempered in Twilight
+Button/Name/AP_ArtanisAntiAirEnable=Enable Anti-Air Weapon
+Button/Name/AP_ArtanisAntiAirDisable=Disable Anti-Air Weapon
+Button/Tooltip/AP_ArtanisPassiveSystems=Open Artanis' passive systems and weapon toggles.
+Button/Tooltip/AP_ArtanisTemperedInTwilight=Artanis restores 2 energy whenever his melee or anti-air weapon deals damage.
+Button/Tooltip/AP_ArtanisAntiAirEnable=Enable Artanis' anti-air ranged weapon.
+Button/Tooltip/AP_ArtanisAntiAirDisable=Disable Artanis' anti-air ranged weapon.


### PR DESCRIPTION
### Motivation
- Provide a passive that refunds Energy to Artanis when he deals damage with his melee or anti-air weapon to support his ability usage.
- Make Artanis' ranged anti-air weapon unlockable and togglable so it can be hidden/disabled until the player purchases the unlock and the player can enable/disable it in-game.
- Surface the new passive and weapon controls in the unit command card with a small submenu so players can see the passive and use the enable/disable controls from different slots.

### Description
- Added a new upgrade `AP_ArtanisTemperedInTwilight` and a new unlock upgrade `AP_ArtanisUnlockedAntiAirProtocol` that clears the `Options[Disabled]`/`Options[Hidden]` flags on the anti-air weapon when purchased in `UpgradeData.xml`.
- Added a new energy effect `AP_ArtanisTemperedInTwilightEnergy` (`CEffectModifyUnit`) and wired it into `AP_ArtanisBladesSet` and the air-attack impact flow (`AP_ArtanisAirAttackImpactSet`) so both melee hits and air-attack impacts restore `2` Energy when the validator `AP_HaveArtanisTemperedInTwilight` is satisfied (`EffectData.xml`).
- Modified `AP_ArtanisAirAttack` weapon period to `0.8` and set it initially `Disabled`/`Hidden` so the weapon is not usable until unlocked (`WeaponData.xml`).
- Added `AP_ArtanisAirAttackToggle` (a `CAbilBehavior`) and a disabling behavior `AP_ArtanisAirAttackDisabled` (which uses `WeaponDisableArray`) to allow toggling the anti-air weapon on/off; created separate enable/disable button faces and a small passive-systems submenu (`AbilData.xml`, `BehaviorData.xml`, `ButtonData.xml`, `UnitData.xml`).
- Added requirement wrappers/nodes and a player validator (`AP_HaveArtanisTemperedInTwilight`) to control visibility and button state for the passive and toggle buttons (`RequirementData.xml`, `RequirementNodeData.xml`, `ValidatorData.xml`).
- Added English `GameStrings.txt` entries for the new `AP_ArtanisPassiveSystems` submenu, `AP_ArtanisTemperedInTwilight` passive name/tooltip, and the enable/disable button names/tooltips.

### Testing
- Parsed all modified XML files with `python -c "import xml.etree.ElementTree as ET; ET.parse('<file>')"` to confirm the files are well-formed, which succeeded for each modified file.
- Searched the GameData and localization for the new IDs with `rg` to confirm cross-file references (e.g. `AP_ArtanisTemperedInTwilight`, `AP_ArtanisUnlockedAntiAirProtocol`, `AP_ArtanisAirAttackToggle`, `AP_ArtanisAirAttackDisabled`, `AP_ArtanisAirAttackImpactSet`, `AP_ArtanisPassiveSystems`), which returned the expected entries.
- Inspected the specific changed snippets with `nl`/`sed` to verify the new effect arrays, behavior, ability, weapon `Period`/`Options`, upgrade entries, command card `PS` submenu, and localized lines were inserted as intended, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f74779ef48332a8dfb5ffe64fef46)