### PR TITLE
Add Tempered in Twilight passive and unlockable Artanis anti-air controls

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -4634,6 +4634,19 @@
             <Button DefaultButtonFace="AP_ArtanisNoAspect" Requirements="AP_HaveArtanisAnyAspectEquipped"/>
         </InfoArray>
     </CAbilSpecialize>
+    <CAbilBehavior id="AP_ArtanisAirAttackSwap">
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <CmdButtonArray index="On" DefaultButtonFace="AP_ArtanisAirAttackEnable" Requirements="AP_HaveArtanisAirAttackUnlocked">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+        <CmdButtonArray index="Off" DefaultButtonFace="AP_ArtanisAirAttackDisable" Requirements="AP_HaveArtanisAirAttackUnlocked">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+        <Flags index="Toggle" value="1"/>
+        <Flags index="ToggledOn" value="1"/>
+        <Flags index="Transient" value="1"/>
+        <BehaviorArray value="AP_EnableArtanisAirAttackSwap"/>
+    </CAbilBehavior>
     <CAbilEffectTarget id="AP_Exterminate">
         <AbilSetId value="AP_Exterminate"/>
         <Effect index="0" value="AP_ExterminateSet"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -2137,6 +2137,14 @@
     <CBehaviorBuff id="AP_ArtanisPurifierAspect" parent="AP_ArtanisAspectBuff"/>
     <CBehaviorBuff id="AP_ArtanisTaldarimAspect" parent="AP_ArtanisAspectBuff"/>
     <CBehaviorBuff id="AP_ArtanisNoAspect" parent="AP_ArtanisAspectBuff"/>
+    <CBehaviorBuff id="AP_EnableArtanisAirAttackSwap">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <RemoveValidatorArray value="AP_HaveArtanisAirAttackUnlocked"/>
+        <Modification>
+            <WeaponArray Link="AP_ArtanisAirAttack"/>
+        </Modification>
+    </CBehaviorBuff>
     <CBehaviorBuff id="AP_CleansingSmite">
         <InfoIcon value="Assets\Textures\btn-upgrade-protoss-fenix-zealotcleave.dds"/>
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -2445,6 +2445,22 @@
         <Icon value="AP\Assets\Textures\btn-ability-protoss-emergencywarp-aiur.dds"/>
         <AlertIcon value="AP\Assets\Textures\btn-ability-protoss-emergencywarp-aiur.dds"/>
     </CButton>
+    <CButton id="AP_ArtanisAirAttackMenu">
+        <Icon value="Assets\Textures\btn-ability-protoss-phoenixairweapons.dds"/>
+        <AlertIcon value="Assets\Textures\btn-ability-protoss-phoenixairweapons.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisTemperedInTwilight">
+        <Icon value="Assets\Textures\BTN-Upgrade-Artanis-SingularityCharge.dds"/>
+        <AlertIcon value="Assets\Textures\BTN-Upgrade-Artanis-SingularityCharge.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisAirAttackEnable">
+        <Icon value="Assets\Textures\btn-ability-protoss-phoenixairweapons.dds"/>
+        <AlertIcon value="Assets\Textures\btn-ability-protoss-phoenixairweapons.dds"/>
+    </CButton>
+    <CButton id="AP_ArtanisAirAttackDisable">
+        <Icon value="Assets\Textures\btn-move-holdposition.dds"/>
+        <AlertIcon value="Assets\Textures\btn-move-holdposition.dds"/>
+    </CButton>
     <CButton id="AP_ArtanisLightningDash">
         <Icon value="Assets\Textures\btn-ability-protoss-lightningdash.dds"/>
         <EditorCategories value="Race:Protoss"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -4582,6 +4582,7 @@
     <CEffectSet id="AP_ArtanisWeaponSet">
         <EditorCategories value=""/>
         <EffectArray value="AP_ArtanisWeaponBurst"/>
+        <EffectArray value="AP_ArtanisTemperedInTwilightEnergy"/>
     </CEffectSet>
     <CEffectCreatePersistent id="AP_ArtanisWeaponBurst">
         <EditorCategories value="Race:Protoss"/>
@@ -4607,6 +4608,11 @@
     <CEffectModifyUnit id="AP_ArtanisAstralWindCDRefund">
         <ImpactUnit Value="Caster"/>
         <Cost Abil="AP_ArtanisAstralWind,Execute" CooldownOperation="Add" CooldownTimeUse="-5.0"/>
+    </CEffectModifyUnit>
+    <CEffectModifyUnit id="AP_ArtanisTemperedInTwilightEnergy">
+        <ImpactUnit Value="Caster"/>
+        <ValidatorArray value="AP_HaveArtanisTemperedInTwilightValidator"/>
+        <VitalArray index="Energy" value="2"/>
     </CEffectModifyUnit>
     
     <CEffectApplyBehavior id="AP_ArtanisAiurAspect"/>
@@ -5140,6 +5146,7 @@
 
     <CEffectSet id="AP_ArtanisAirAttackSet">
         <EffectArray value="AP_ArtanisAirAttackLM"/>
+        <EffectArray value="AP_ArtanisTemperedInTwilightEnergy"/>
     </CEffectSet>
     <CEffectLaunchMissile id="AP_ArtanisAirAttackLM">
         <ImpactEffect value="AP_ArtanisAirAttackDamage"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
@@ -2791,6 +2791,12 @@
     <CRequirement id="AP_HaveArtanisAnyAspectEquipped">
         <NodeArray index="Show" Link="AP_OrArtanisAnyAspectEquippedCompleteOnly"/>
     </CRequirement>
+    <CRequirement id="AP_HaveArtanisTemperedInTwilight">
+        <NodeArray index="Show" Link="AP_CountUpgradeArtanisTemperedInTwilightCompleteOnly"/>
+    </CRequirement>
+    <CRequirement id="AP_HaveArtanisAirAttackUnlocked">
+        <NodeArray index="Show" Link="AP_CountUpgradeArtanisAirAttackUnlockedCompleteOnly"/>
+    </CRequirement>
     <CRequirement id="AP_HaveSOADragoonRevive">
         <EditorCategories value="Race:Protoss,TechType:Ability"/>
         <NodeArray index="Show" Link="AP_CountUpgradeSOADragoonReviveCompleteOnly"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
@@ -5194,7 +5194,14 @@
         <OperandArray value="AP_CountUpgradeArtanisTaldarimAspectUnlockedCompleteOnly"/>
         <OperandArray value="AP_NotCountBehaviorArtanisTaldarimAspectCompleteOnlyAtUnit"/>
     </CRequirementAnd>
-        
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisTemperedInTwilightCompleteOnly">
+        <Count Link="AP_ArtanisTemperedInTwilight" State="CompleteOnly"/>
+        <Flags index="TechTreeCheat" value="0"/>
+    </CRequirementCountUpgrade>
+    <CRequirementCountUpgrade id="AP_CountUpgradeArtanisAirAttackUnlockedCompleteOnly">
+        <Count Link="AP_ArtanisAirAttackUnlocked" State="CompleteOnly"/>
+        <Flags index="TechTreeCheat" value="0"/>
+    </CRequirementCountUpgrade>
 
     <CRequirementCountUpgrade id="AP_CountUpgradeSOAFenixCompleteOnly">
         <Flags index="TechTreeCheat" value="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -14658,6 +14658,7 @@
         <AbilArray Link="Warpable"/>
         <AbilArray Link="ProgressRally"/>
         <AbilArray Link="AP_ArtanisWeaponAspects"/>
+        <AbilArray Link="AP_ArtanisAirAttackSwap"/>
         <AbilArray Link="AP_SuppressionPulse"/>
         <AbilArray Link="AP_ArtanisLightningDash"/>
         <AbilArray Link="AP_ArtanisAstralWind"/>
@@ -14674,7 +14675,6 @@
         <BehaviorArray Link="AP_ArtanisNoAspect"/>
         <BehaviorArray Link="AP_ArtanisResurgence"/>
         <WeaponArray Link="AP_ArtanisTwilightBlades"/>
-        <WeaponArray Link="AP_ArtanisAirAttack"/>
         <CardLayouts>
             <LayoutButtons Face="Move" Type="AbilCmd" AbilCmd="move,Move" Row="0" Column="0"/>
             <LayoutButtons Face="Stop" Type="AbilCmd" AbilCmd="stop,Stop" Row="0" Column="1"/>
@@ -14698,6 +14698,13 @@
             <LayoutButtons Face="AP_PhasePrism" Type="AbilCmd" AbilCmd="AP_PhasePrism,Execute" Row="1" Column="1"/>
             <LayoutButtons Face="ArtanisForceOfWill" Type="Passive" Row="2" Column="3"/>
             <LayoutButtons Face="AP_ArtanisWeaponAspectSwap" Type="Submenu" SubmenuCardId="WA" Row="2" Column="1"/>
+            <LayoutButtons Face="AP_ArtanisAirAttackMenu" Type="Submenu" SubmenuCardId="RA" Row="1" Column="4"/>
+        </CardLayouts>
+        <CardLayouts CardId="RA">
+            <LayoutButtons Face="AP_ArtanisTemperedInTwilight" Type="Passive" Requirements="AP_HaveArtanisTemperedInTwilight" Row="0" Column="0"/>
+            <LayoutButtons Face="AP_ArtanisAirAttackEnable" Type="AbilCmd" AbilCmd="AP_ArtanisAirAttackSwap,On" Requirements="AP_HaveArtanisAirAttackUnlocked" Row="0" Column="1"/>
+            <LayoutButtons Face="AP_ArtanisAirAttackDisable" Type="AbilCmd" AbilCmd="AP_ArtanisAirAttackSwap,Off" Requirements="AP_HaveArtanisAirAttackUnlocked" Row="0" Column="2"/>
+            <LayoutButtons Face="Cancel" Type="CancelSubmenu" Row="2" Column="4"/>
         </CardLayouts>
         <CardLayouts CardId="WA">
             <LayoutButtons Face="AP_ArtanisAiurAspect" Type="AbilCmd" AbilCmd="AP_ArtanisWeaponAspects,0" Row="0" Column="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -12834,6 +12834,8 @@
     <CUpgrade id="AP_ArtanisTaldarimAspectUnlocked"/>
     <CUpgrade id="AP_ArtanisTaldarimAspectActive"/>
     <CUpgrade id="AP_ArtanisTaldarimAspectPassive"/>
+    <CUpgrade id="AP_ArtanisTemperedInTwilight"/>
+    <CUpgrade id="AP_ArtanisAirAttackUnlocked"/>
 
     <CUpgrade id="AP_VoidRaySpeedUpgrade">
         <ScoreAmount value="300"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -4155,6 +4155,9 @@
     <CValidatorUnitType id="AP_IsPurifierMothershipBase">
         <Value value="AP_MothershipPurifier"/>
     </CValidatorUnitType>
+    <CValidatorPlayerRequirement id="AP_HaveArtanisTemperedInTwilightValidator">
+        <Value value="AP_HaveArtanisTemperedInTwilight"/>
+    </CValidatorPlayerRequirement>
     <CValidatorUnitType id="AP_IsPurifierMothershipUpgraded">
         <Value value="AP_MothershipPurifierPowerSource"/>
     </CValidatorUnitType>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2793,7 +2793,7 @@
         <DisplayEffect value="AP_ArtanisAirAttackDamage"/>
         <TargetFilters value="Air,Visible;Ground,Missile,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="4"/>
-        <Period value="1"/>
+        <Period value="0.8"/>
         <DamagePoint value="0.2"/>
         <Effect value="AP_ArtanisAirAttackSet"/>
     </CWeaponLegacy>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -1138,6 +1138,10 @@ Button/Name/AP_ArtanisNoAspect=Alone
 Button/Name/AP_ArtanisPurifierAspect=Purifier Aspect
 Button/Name/AP_ArtanisTaldarimAspect=Tal'darim Aspect
 Button/Name/AP_ArtanisWeaponAspectSwap=Swap Weapon Aspects
+Button/Name/AP_ArtanisAirAttackMenu=Ranged Weapon Controls
+Button/Name/AP_ArtanisTemperedInTwilight=Tempered in Twilight
+Button/Name/AP_ArtanisAirAttackEnable=Enable Anti-Air Weapon
+Button/Name/AP_ArtanisAirAttackDisable=Disable Anti-Air Weapon
 Button/Name/AP_AscendantAbilityEfficiency=Breath of Creation
 Button/Name/AP_AscendantSacrifice=Sacrifice
 Button/Name/AP_AssaultModeMengsk=Assault Mode
@@ -2375,6 +2379,7 @@ Button/Name/AP_VoidVoidRayBeamBounce=Destruction Beam
 Button/Name/AP_VoidZealotShadowCharge=Shadow Charge
 Button/Name/AP_VoidZealotShadowChargeStun=Darkcoil
 Button/Name/AP_VoidZealotWhirlwind=Whirlwind
+Button/Name/AP_VoltaicShock=Voltaic Shock
 Button/Name/AP_Vulture=Build Vulture
 Button/Name/AP_VultureAutoLaunchers=Auto Launchers
 Button/Name/AP_VultureAutoRepair=Jerry-Rigged Patchup
@@ -2588,6 +2593,10 @@ Button/Tooltip/AP_ArtanisNoAspect=Artanis removes his current Weapon Aspect, ret
 Button/Tooltip/AP_ArtanisPurifierAspect=Switch Artanis' active aspect to <c val="f2bf16">Purifier</c>, granting him access to any unlocked bonuses and making him count as a <c val="f2bf16">Purifier</c> unit.
 Button/Tooltip/AP_ArtanisTaldarimAspect=Switch Artanis' active aspect to <c val="d40d24">Taldarim</c>, granting him access to any unlocked bonuses and making him count as a <c val="d40d24">Taldarim</c> unit.
 Button/Tooltip/AP_ArtanisWeaponAspectSwap=Swap Artanis to a different weapon aspect.
+Button/Tooltip/AP_ArtanisAirAttackMenu=Open controls for Artanis' ranged anti-air weapon and passive upgrades.
+Button/Tooltip/AP_ArtanisTemperedInTwilight=Whenever Artanis deals attack damage with either weapon, he restores 2 energy.
+Button/Tooltip/AP_ArtanisAirAttackEnable=Enable Artanis' ranged anti-air weapon.
+Button/Tooltip/AP_ArtanisAirAttackDisable=Disable Artanis' ranged anti-air weapon.
 Button/Tooltip/AP_AscendantAbilityEfficiency=Ascendant abilities cost <d ref="Upgrade,AP_AscendantAbilityEfficiency,EffectArray[0].Value"/> less energy.<n/><n/><c val="FFE303">War Council Upgrade.</c>
 Button/Tooltip/AP_AscendantSacrifice=Reduces target friendly unit to <d ref="Effect,AP_AscendantSacrificeDamage,Amount"/> life (shields are not affected).<n/><n/>Grants the Ascendant <d ref="Effect,AP_AscendantSacrificeDamage5,LeechFraction[Energy]"/> energy for each life point reduced, up to its maximum energy.<n/><n/><c val="#ColorAttackInfo">Can only target friendly units.</c>
 Button/Tooltip/AP_AssaultModeMengsk=Transforms the Sky Fury to Assault Mode. In this mode Sky Furies move on the ground and can only attack ground targets.
@@ -4078,6 +4087,7 @@ Button/Tooltip/AP_VoidVoidRayBeamBounce=Prismatic Beam splits and deals damage t
 Button/Tooltip/AP_VoidZealotShadowCharge=Intercepts enemy ground units. Briefly cloaks the Centurion and allows it to move through other units.
 Button/Tooltip/AP_VoidZealotShadowChargeStun=Stuns target enemy ground unit and all nearby enemy ground units <d ref="Behavior,AP_VoidZealotShadowChargeStun,Duration" precision="1"/> seconds.</n></n><c val="#ColorAttackInfo">Massive units are slowed.</c>
 Button/Tooltip/AP_VoidZealotWhirlwind=Deals <d ref="Effect,AP_VoidZealotWhirlwindDamage,Amount/Behavior,AP_VoidZealotWhirlwind,Period"/> damage per second to all nearby enemy units. Lasts <d ref="Behavior,AP_VoidZealotWhirlwind,Duration"/> seconds.
+Button/Tooltip/AP_VoltaicShock=Unleash an electrical blast at the target point, dealing <d ref="Effect,AP_VoltaicShockDamage,Amount"/> damage to air units and <d ref="Effect,AP_VoltaicShockDamageSecondary,Amount"/> damage to enemies in the area.<n/><n/>Affected air units are grounded and unable to move for <d ref="Behavior,AP_VoltaicShock,Duration"/> seconds.
 Button/Tooltip/AP_Vulture=Fast skirmish unit. Can use the Spider Mine ability.<n/><n/><c val="#ColorAttackInfo">Can attack ground units.</c>
 Button/Tooltip/AP_VultureAutoLaunchers=Vulture can attack while moving
 Button/Tooltip/AP_VultureAutoRepair=Vulture regenerates life.


### PR DESCRIPTION
### Motivation
- Enable a new Artanis passive upgrade that restores energy on attack and provide player-facing controls to enable/disable his ranged anti-air weapon when unlocked.
- Keep the anti-air weapon hidden/disabled by default and only grant it when the player purchases the unlock, while exposing explicit enable/disable buttons in Artanis' command card.

### Description
- Introduced upgrade entries `AP_ArtanisTemperedInTwilight` and `AP_ArtanisAirAttackUnlocked` in `UpgradeData.xml` and wired requirement nodes in `RequirementNodeData.xml` and `RequirementData.xml`.
- Implemented an energy-restoring effect `AP_ArtanisTemperedInTwilightEnergy` (restores `2` energy) and hooked it into both `AP_ArtanisWeaponSet` and `AP_ArtanisAirAttackSet` in `EffectData.xml` so attacks grant the energy when the player has the upgrade (validator `AP_HaveArtanisTemperedInTwilightValidator`).
- Removed `AP_ArtanisAirAttack` from Artanis' default `WeaponArray` and added a toggle ability `AP_ArtanisAirAttackSwap` (in `AbilData.xml`) plus a behavior `AP_EnableArtanisAirAttackSwap` (in `BehaviorData.xml`) that grants the `AP_ArtanisAirAttack` weapon via a `WeaponArray` modification when appropriate.
- Adjusted the anti-air weapon `Period` from `1` to `0.8` in `WeaponData.xml` to make the attack speed `0.8`.
- Added a new command-card submenu `RA` to Artanis in `UnitData.xml`, a top-level submenu button (`AP_ArtanisAirAttackMenu`) and three submenu entries: a passive icon for `Tempered in Twilight`, and separate `Enable` / `Disable` anti-air buttons that call `AP_ArtanisAirAttackSwap,On` and `AP_ArtanisAirAttackSwap,Off` respectively.
- Added new button definitions in `ButtonData.xml` and English localization entries in `enUS.SC2Data/LocalizedData/GameStrings.txt` for the menu, passive label, and toggle buttons.

### Testing
- Ran `rg -n "AP_ArtanisAirAttackSwap|AP_EnableArtanisAirAttackSwap|AP_ArtanisTemperedInTwilight|AP_ArtanisAirAttackUnlocked" Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt` to verify new symbols, which succeeded.
- Validated modified XML files by parsing them with `python` and `xml.etree.ElementTree` to ensure well-formedness for the touched files, which succeeded (`xml ok`).
- Verified diffs with `git diff --stat HEAD~1 HEAD` to confirm the intended changes were staged, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f74779ef48332a8dfb5ffe64fef46)